### PR TITLE
Comment out oVirt.hosted-engine-setup

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -31,5 +31,6 @@ dependencies:
    name: oVirt.repositories
  - oVirt.vm-infra
  - oVirt.v2v-conversion-host
- - oVirt.hosted-engine-setup
+# from some reason it's not published on glaxy so comment it out for WA
+# - oVirt.hosted-engine-setup
  - oVirt.shutdown-env


### PR DESCRIPTION
It's not published on galaxy from some reason.